### PR TITLE
Mementos not saving without an attached moment

### DIFF
--- a/server/api/mementos/mementos-router.js
+++ b/server/api/mementos/mementos-router.js
@@ -85,9 +85,11 @@ mementosRouter.post('/', function(req, res) {
       },recipients)
       .then(function (mementoID) {
         db.Moments.where({id : momentID}).fetch().then(function (moment) {
-          moment.set('memento_id', mementoID).save().then(function () {
-            res.status(201).send(mementoID);
-          });
+          if(moment) {
+            moment.set('memento_id', mementoID).save().then(function () {
+              res.status(201).send(mementoID);
+            });
+          }
         });
       })
       .catch(function (err) {


### PR DESCRIPTION
Mementos were not saving if there wasn't a moment attached to them.
This changes fixes that. If a moment has been attached, then the moment will be saved.
Otherwise, it won't error any more.